### PR TITLE
Code area scrollbars

### DIFF
--- a/themes/generative-artistry/static/css/style.css
+++ b/themes/generative-artistry/static/css/style.css
@@ -211,7 +211,7 @@ article:last-of-type {
 }
 
 .chroma {
-  overflow: scroll;
+  overflow: auto;
 }
 
 @media only screen and (max-width: 900px) {


### PR DESCRIPTION
Fixes an issue where the scrollbars always show even if the content does not need to be scrolled

<img width="541" alt="screen shot 2018-06-11 at 10 16 13 am" src="https://user-images.githubusercontent.com/1614329/41246785-f6219630-6d60-11e8-875d-15cdf35dd5be.png">

vs 

<img width="542" alt="screen shot 2018-06-11 at 10 20 04 am" src="https://user-images.githubusercontent.com/1614329/41246816-08f649d6-6d61-11e8-9cbb-dbe8ad0a8cf4.png">
