### PR TITLE
rss template and more frontmatter

### DIFF
--- a/content/episodes/intoduction.md
+++ b/content/episodes/intoduction.md
@@ -1,19 +1,34 @@
 +++
-title = "Introducing the generative artistry podcast"
+title = "Introducing the Generative Artistry Podcast"
 date = 2019-02-28T09:59:00-04:00
 image = "/img/introduction.png"
 iama = "episode"
 teaser = "Ruth and Tim get to talking about what they want to get out of this podcast, where we want to take it, and preaching the good word of creative code, and generative art."
+
+author = Ruth John & Tim Holman
+mp3 = http://someurlhere.mp3
+ogg = http://someotherurlhere.ogg
+duration = "32:54"
+length = 123456789
+number = "01"
+tags =
+	- generative artistry
+	- random numbers
+	- chat
+	- art
 +++
 
-# Introduction!
+# Introduction! 
 
-Video player up in this!
+~Video~ Audio player up in this!
 
 
 - List item
 - Links that are cool
 - Perhaps some kind of text translations
+- itunes, spotify, those kind of links (download)
+- subscribe SUBSCRIBE
+- Transcription
 
 
 Ruth and Tim get to talking about what they want to get out of this podcast, where we want to take it, and preaching the good word of creative code, and generative art. Ruth and Tim get to talking about what they want to get out of this podcast, where we want to take it, and preaching the good word of creative code, and generative art.

--- a/layouts/podcast.xml
+++ b/layouts/podcast.xml
@@ -1,0 +1,58 @@
+<rss version="2.0"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+     xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+     xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+     xmlns:itunesu="http://www.itunesu.com/feed"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel> 
+    <title>{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}</title>
+    <atom:link href="{{ .Site.BaseURL }}/podcast.xml" rel="self" type="application/rss+xml" />
+    <link>{{ .Site.BaseURL }}</link>
+    <description>Recent content {{ with .Title }}in {{.}} {{ end }}on {{ .Site.Title }}</description>
+    <lastBuildDate>{{ .Date }}</lastBuildDate>
+    <sy:updatePeriod>hourly</sy:updatePeriod>
+    <sy:updateFrequency>1</sy:updateFrequency>
+    <language>en</language>
+    <copyright>{{ with .Site.Copyright }}{{.}}{{ end }}</copyright>
+    <image>
+      <url>img/introduction.png</url>
+      <title>Generative Artistry</title>
+      <link>http://www.generativeartistry.com</link>
+    </image>
+    <itunes:new-feed-url>{{ .Site.BaseURL }}/podcasts/index.xml</itunes:new-feed-url>
+    <itunes:subtitle>"Some subtitle here"</itunes:subtitle>
+    <itunes:summary>"A podcast about ..."</itunes:summary>
+    <itunes:category text="Art">
+        <itunes:category text="Visual Art" />
+    </itunes:category>
+    <itunes:author>"Ruth John & Tim Holman"</itunes:author>
+    <itunes:owner>
+        <itunes:name>"Ruth John"</itunes:name>
+        <itunes:email>"rumyra@gmail.com"</itunes:email>
+    </itunes:owner>
+    <itunes:block>no</itunes:block>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:image href="img/introduction.png" />
+    {{ range first 15 .Data.Pages }}
+    <item>
+        <link>{{ .Permalink }}</link>
+        <title>{{ .Title }}</title>
+        <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+        <description>{{ .Params.summary }}</description>
+
+        <enclosure url="{{ .Params.mp3 }}" length="{{ .Params.length }}" type="audio/mpeg" />
+        <guid>{{ .Params.mp3 }}</guid>
+
+        <itunes:author>{{ .Params.author }}</itunes:author>
+        <itunes:summary>{{ .Content | html }}</itunes:summary>
+        <itunes:image href="http://drops.albush.com/RAX%20CLOUD%20OFFICE%20HANGOUT%20FINAL.png" />
+        <itunes:duration>{{ .Params.duration }}</itunes:duration>
+        <itunes:keywords>{{ .Params.tags }}</itunes:keywords>
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
This was branched from the podcast branch

* An XML file which most likely does not work - it's just the format
* Added front matter which is needed for rss into the episode 'introduction' so we know what we're working with (things like audio file, length etc...)

Hooking it all up still needs doing & I wasn't sure where the xml file should go... I haven't built it at all. I judged Hugo based on other static site things I have used and read no documentation whatsoever because I am worth it (10x) Tim 🙈