### PR TITLE
Add prefers-reduced-motion detection to podcast eps for better a11y

### DIFF
--- a/static/js/transcription-markdown.js
+++ b/static/js/transcription-markdown.js
@@ -1,7 +1,9 @@
 // Version 0.1, lets get it working first
 
 (function() {
-	var interactiveMode = true;
+	var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+	var interactiveMode;
+
 	var currentTime = 0;
 	var active = false;
 	var currentActiveTime = null;
@@ -22,7 +24,18 @@
 		if (interactiveMode) checkUpdate();
 	});
 
+	prefersReducedMotion.addEventListener('change', () => {
+		setInteractiveMode();
+	});
+
 	const nodeData = [];
+
+	function setInteractiveMode() {
+	// turns off interactive mode if user has preferences for prefers-reduced-motion
+		interactiveMode = !prefersReducedMotion.matches;		
+		interactiveCheckbox.checked = interactiveMode;
+	}
+
 	function getAndPrepTimes() {
 		const nodes = document.querySelectorAll("[data-time]");
 		nodes.forEach(node => {
@@ -52,5 +65,6 @@
 		}
 	}
 
+	setInteractiveMode();
 	getAndPrepTimes();
 })();


### PR DESCRIPTION
Currently interactive mode is enabled by default, but if a user has [prefers-reduced-motion](https://developers.google.com/web/updates/2019/03/prefers-reduced-motion) enabled on their system, the sudden scrolling of the page could be disorienting before they figure out how to turn it off.

This change checks to see if the user has `prefers-reduced-motion` enabled and sets the default interactive mode based on that preference (turned off if so, turned on otherwise or if their OS doesn't support the option). 